### PR TITLE
Updating lookdev for normals fix

### DIFF
--- a/assets/odie/render/surface/payload.usda
+++ b/assets/odie/render/surface/payload.usda
@@ -2,22 +2,98 @@
 (
     defaultPrim = "main"
     endTimeCode = 1
+    framesPerSecond = 24
     metersPerUnit = 0.01
     startTimeCode = 1
+    timeCodesPerSecond = 24
     upAxis = "Y"
 )
 
 over "main"
 {
+    def Material "odie_eye_light" (
+        prepend apiSchemas = ["MaterialXConfigAPI"]
+    )
+    {
+        string config:mtlx:version = "1.39"
+        token outputs:mtlx:surface.connect = </main/odie_eye_light/mtlxstandard_surface.outputs:out>
+
+        def Shader "mtlxstandard_surface"
+        {
+            uniform token info:id = "ND_standard_surface_surfaceshader"
+            float inputs:base
+            color3f inputs:base_color
+            float inputs:coat
+            float inputs:coat_roughness
+            float inputs:emission = 1
+            color3f inputs:emission_color = (5, 5, 1)
+            float inputs:metalness
+            float inputs:specular
+            color3f inputs:specular_color
+            float inputs:specular_IOR
+            float inputs:specular_roughness
+            float inputs:transmission
+            token outputs:out
+        }
+    }
+
+    def Material "odie_glass_face_mtl" (
+        prepend inherits = </__class_mtl__/odie_glass_face_mtl>
+    )
+    {
+        int inputs:inputnum = 1
+        token outputs:mtlx:surface.connect = </main/odie_glass_face_mtl/mtlxmaterial.outputs:surface>
+
+        def NodeGraph "mtlxmaterial"
+        {
+            token outputs:surface.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxsurface1.outputs:out>
+
+            def Shader "mtlxsurface1"
+            {
+                uniform token info:id = "ND_surface"
+                string inputs:bsdf.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxlayer1.outputs:out>
+                token outputs:out
+            }
+
+            def Shader "mtlxlayer1"
+            {
+                uniform token info:id = "ND_layer_bsdf"
+                string inputs:base.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxdielectric_bsdf1.outputs:out>
+                string inputs:top.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxdielectric_bsdf2.outputs:out>
+                token outputs:out
+            }
+
+            def Shader "mtlxdielectric_bsdf2"
+            {
+                uniform token info:id = "ND_dielectric_bsdf"
+                float inputs:ior = 1.8
+                float2 inputs:roughness = (0.001, 0.001)
+                color3f inputs:tint = (-0.027333332, 0.111999996, 0.17933333)
+                float inputs:weight = 0.821
+                token outputs:out
+            }
+
+            def Shader "mtlxdielectric_bsdf1"
+            {
+                uniform token info:id = "ND_dielectric_bsdf"
+                float2 inputs:roughness = (0.001, 0.001)
+                string inputs:scatter_mode = "T"
+                token outputs:out
+            }
+        }
+    }
+
     def Material "odie_mtl" (
         prepend inherits = </__class_mtl__/odie_mtl>
     )
     {
-        int inputs:inputnum = 1
+        int inputs:inputnum = 2
+        token outputs:mtlx:displacement.connect = </main/odie_mtl/mtlxmaterial.outputs:displacement>
         token outputs:mtlx:surface.connect = </main/odie_mtl/mtlxmaterial.outputs:surface>
 
         def NodeGraph "mtlxmaterial"
         {
+            token outputs:displacement.connect = </main/odie_mtl/mtlxmaterial/mtlxdisplacement.outputs:out>
             token outputs:surface.connect = </main/odie_mtl/mtlxmaterial/mtlxsurface1.outputs:out>
 
             def Shader "mtlxsurface1"
@@ -70,8 +146,8 @@ over "main"
             def Shader "mtlxburley_diffuse_bsdf1"
             {
                 uniform token info:id = "ND_burley_diffuse_bsdf"
+                color3f inputs:color = (0, 1, 0.5)
                 color3f inputs:color.connect = </main/odie_mtl/mtlxmaterial/cartoon_base_color_texture.outputs:rgb>
-                vector3f inputs:normal.connect = </main/odie_mtl/mtlxmaterial/cartoon_normal_map.outputs:rgb>
                 float inputs:roughness.connect = </main/odie_mtl/mtlxmaterial/cartoon_roughness_texture.outputs:r>
                 token outputs:out
             }
@@ -79,22 +155,24 @@ over "main"
             def Shader "cartoon_base_color_texture"
             {
                 uniform token info:id = "ND_UsdUVTexture"
-                asset inputs:file = @textures/odie_cartoon_color_01.exr@
+                asset inputs:file = @./textures/odie_cartoon_color_01.exr@
+                float2 inputs:st.connect = </main/odie_mtl/mtlxmaterial/mtlxUsdPrimvarReader1.outputs:out>
                 color3f outputs:rgb
+            }
+
+            def Shader "mtlxUsdPrimvarReader1"
+            {
+                uniform token info:id = "ND_UsdPrimvarReader_vector2"
+                string inputs:varname = "st"
+                float2 outputs:out
             }
 
             def Shader "cartoon_roughness_texture"
             {
                 uniform token info:id = "ND_UsdUVTexture"
-                asset inputs:file = @textures/odie_cartoon_rough_01.exr@
+                asset inputs:file = @./textures/odie_cartoon_rough_01.exr@
+                float2 inputs:st.connect = </main/odie_mtl/mtlxmaterial/mtlxUsdPrimvarReader1.outputs:out>
                 float outputs:r
-            }
-
-            def Shader "cartoon_normal_map"
-            {
-                uniform token info:id = "ND_UsdUVTexture"
-                asset inputs:file = @textures/odie_cartoon_norm_01.exr@
-                color3f outputs:rgb
             }
 
             def Shader "mtlxconductor_bsdf1"
@@ -103,6 +181,7 @@ over "main"
                 color3f inputs:extinction.connect = </main/odie_mtl/mtlxmaterial/mtlxartistic_ior1.outputs:extinction>
                 color3f inputs:ior.connect = </main/odie_mtl/mtlxmaterial/mtlxartistic_ior1.outputs:ior>
                 float2 inputs:roughness = (0.1, 0.1)
+                float inputs:weight = 0.196
                 token outputs:out
             }
 
@@ -118,81 +197,25 @@ over "main"
             def Shader "cartoon_metallic_texture"
             {
                 uniform token info:id = "ND_UsdUVTexture"
-                asset inputs:file = @textures/odie_cartoon_metal_01.exr@
+                asset inputs:file = @./textures/odie_cartoon_metal_01.exr@
+                color3f outputs:rgb
+            }
+
+            def Shader "mtlxdisplacement"
+            {
+                uniform token info:id = "ND_displacement_vector3"
+                vector3f inputs:displacement.connect = </main/odie_mtl/mtlxmaterial/cartoon_normal_map.outputs:rgb>
+                token outputs:out
+            }
+
+            def Shader "cartoon_normal_map"
+            {
+                uniform token info:id = "ND_UsdUVTexture"
+                color4f inputs:fallback = (0.47553638, 0.47623226, 0.47622293, 1)
+                asset inputs:file = @./textures/odie_cartoon_norm_01.tga@
                 color3f outputs:rgb
             }
         }
     }
-
-    def Material "odie_glass_face_mtl" (
-        prepend inherits = </__class_mtl__/odie_glass_face_mtl>
-    )
-    {
-        int inputs:inputnum = 1
-        token outputs:mtlx:surface.connect = </main/odie_glass_face_mtl/mtlxmaterial.outputs:surface>
-
-        def NodeGraph "mtlxmaterial"
-        {
-            token outputs:surface.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxsurface1.outputs:out>
-
-            def Shader "mtlxsurface1"
-            {
-                uniform token info:id = "ND_surface"
-                string inputs:bsdf.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxlayer1.outputs:out>
-                token outputs:out
-            }
-
-            def Shader "mtlxlayer1"
-            {
-                uniform token info:id = "ND_layer_bsdf"
-                string inputs:base.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxdielectric_bsdf1.outputs:out>
-                string inputs:top.connect = </main/odie_glass_face_mtl/mtlxmaterial/mtlxdielectric_bsdf2.outputs:out>
-                token outputs:out
-            }
-
-            def Shader "mtlxdielectric_bsdf2"
-            {
-                uniform token info:id = "ND_dielectric_bsdf"
-                float inputs:ior = 1.8
-                float2 inputs:roughness = (0.001, 0.001)
-                color3f inputs:tint = (-0.027333332, 0.111999996, 0.17933333)
-                float inputs:weight = 0.821
-                token outputs:out
-            }
-
-            def Shader "mtlxdielectric_bsdf1"
-            {
-                uniform token info:id = "ND_dielectric_bsdf"
-                float2 inputs:roughness = (0.001, 0.001)
-                string inputs:scatter_mode = "T"
-                token outputs:out
-            }
-        }
-    }
-
-    def Material "odie_eye_light" (
-        prepend apiSchemas = ["MaterialXConfigAPI"]
-    )
-    {
-        string config:mtlx:version = "1.39"
-        token outputs:mtlx:surface.connect = </main/odie_eye_light/mtlxstandard_surface.outputs:out>
-
-        def Shader "mtlxstandard_surface"
-        {
-            uniform token info:id = "ND_standard_surface_surfaceshader"
-            float inputs:base
-            color3f inputs:base_color
-            float inputs:coat
-            float inputs:coat_roughness
-            float inputs:emission = 1
-            color3f inputs:emission_color = (5, 5, 1)
-            float inputs:metalness
-            float inputs:specular
-            color3f inputs:specular_color
-            float inputs:specular_IOR
-            float inputs:specular_roughness
-            float inputs:transmission
-            token outputs:out
-        }
-    }
 }
+


### PR DESCRIPTION
Updating lookdev: replacing normal mapping to pipe into displacement instead.

We should fix the normal map in project 2.